### PR TITLE
Updated GetDuctDim method

### DIFF
--- a/BuildingCoder/BuildingCoder/CmdDuctResize.cs
+++ b/BuildingCoder/BuildingCoder/CmdDuctResize.cs
@@ -44,13 +44,15 @@ namespace BuildingCoder
     /// diameter if round, else height.
     /// </summary>
     static double GetDuctDim( Duct d )
-    {
-      ConnectorProfileType shape = d.DuctType.Shape;
-
-      return ConnectorProfileType.Round == shape
-        ? d.Diameter
-        : d.Height;
-    }
+		{
+			double? ductD = d.Diameter;
+			if (ductD == null) {
+				return d.Height;
+			}
+			else {
+				return d.Diameter;
+			}
+		}
 
     /// <summary>
     /// Return dimension for this connector:


### PR DESCRIPTION
Made nullable double to catch if duct dimension property throws a null reference exception.