### PR TITLE
 Delete temporary GroupType after deleting temporary Group

### DIFF
--- a/BuildingCoder/BuildingCoder/CmdDuplicateElements.cs
+++ b/BuildingCoder/BuildingCoder/CmdDuplicateElements.cs
@@ -65,6 +65,8 @@ namespace BuildingCoder
         Group group = doc.Create.NewGroup( // 2013
           uidoc.Selection.GetElementIds() );
 
+        GroupType groupType = group.GroupType;
+
         LocationPoint location = group.Location
           as LocationPoint;
 
@@ -81,6 +83,8 @@ namespace BuildingCoder
 
         ICollection<ElementId> eIds
           = newGroup.UngroupMembers(); // 2013
+
+        doc.Delete2( groupType );
 
         // change the property or parameter values
         // of the member elements as required...


### PR DESCRIPTION
The CmdDuplicateElements example does what it's supposed to do, but doesn't clean up after itself: it creates a temporary group, which means creating a GroupType and a Group, then it deletes the Group only, leaving the GroupType behind.

I added two lines to delete the temporary GroupType.